### PR TITLE
corrected one-hot encoding to label encoding in text description

### DIFF
--- a/FinalProject.ipynb
+++ b/FinalProject.ipynb
@@ -2255,7 +2255,7 @@
         "*   ISBN\n",
         "*   ISBN13\n",
         "\n",
-        "The following discrete colunms have been one-hot encoded, so we drop the text columns:\n",
+        "The following discrete columns have been label encoded, so we drop the text columns (one-hot encoding would not be suitable given the large size of the inputs, so label encoding was used instead):\n",
         "*   Authors\n",
         "*   Language Code\n",
         "*   Publisher\n",

--- a/index.html
+++ b/index.html
@@ -9660,7 +9660,7 @@ To: /content/books.csv
 <li>ISBN</li>
 <li>ISBN13</li>
 </ul>
-<p>The following discrete colunms have been one-hot encoded, so we drop the text columns:</p>
+<p>The following discrete columns have been label encoded, so we drop the text columns (one-hot encoding would not be suitable given the large size of the inputs, so label encoding was used instead):</p>
 <ul>
 <li>Authors</li>
 <li>Language Code</li>


### PR DESCRIPTION
Correction from "one-hot encoding" to "label encoding"